### PR TITLE
ezone.hk 即時科技生活新聞

### DIFF
--- a/app/templates/base.html.j2
+++ b/app/templates/base.html.j2
@@ -1,7 +1,7 @@
 {% extends 'bootstrap/base.html' %}
 {% block title %}
     {% if title %}
-        {{ title }} - Microblog
+        ezone.hk 即時科技生活新聞
     {% else %}
         {{ _('Welcome to Microblog') }}
     {% endif %}


### PR DESCRIPTION
replaced tag name to ezone(backup version)